### PR TITLE
Fixed PHP error caused by reviews and rating stars being displayed on not single product pages.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 /*
   Plugin Name: WooCommerce Reputations
   Plugin URI: https://github.com/netzstrategen/woocommerce-reputations
-  Version: 1.3.0
+  Version: 1.3.1
   Text Domain: woocommerce-reputations
   Description: Integrate Trusted Shops and Google Trusted Stores into WooCommerce.
   Author: netzstrategen

--- a/src/TrustedShops.php
+++ b/src/TrustedShops.php
@@ -147,6 +147,11 @@ EOD;
     $disable_responsive = Settings::getOption('trusted_shops/disable_responsive') === 'yes' ? TRUE : FALSE;
     $display_product_reviews = Settings::getOption('trusted_shops/display_product_reviews') === 'yes' ? TRUE : FALSE;
     $display_product_stars = Settings::getOption('trusted_shops/display_product_stars') === 'yes' ? TRUE : FALSE;
+
+    if (!is_product() || !$product_sku = $product->get_sku()) {
+      $display_product_stars = FALSE;
+      $display_product_reviews = FALSE;
+    }
     ?>
     <script>
       (function () {
@@ -173,11 +178,11 @@ EOD;
     </script>
   <?php if ($display_product_stars) { ?>
     <script type="text/javascript" src="//widgets.trustedshops.com/reviews/tsSticker/tsProductStickerSummary.js"></script>
-    <script> 
+    <script>
       var summaryBadge = new productStickerSummary();
       summaryBadge.showSummary({
         'tsId': '<?= $shop_id ?>',
-        'sku': ['<?= $product->get_sku() ?>'],
+        'sku': ['<?= $product_sku ?>'],
         'element': '#<?= Plugin::PREFIX . "-trusted-shops-product-stars" ?>',
         'starColor': '<?= Settings::getOption('trusted_shops/product_stars_color') ?? "#FFDC0F" ?>',
         'starSize': '14px',
@@ -186,13 +191,13 @@ EOD;
         'scrollToReviews': 'false',
         'enablePlaceholder': 'false'
       });
-    </script> 
+    </script>
   <?php } ?>
   <?php if ($display_product_reviews) { ?>
     <script type="text/javascript">
       _tsProductReviewsConfig = {
         tsid: '<?= $shop_id ?>',
-        sku: ['<?= $product->get_sku() ?>'],
+        sku: ['<?= $product_sku ?>'],
         variant: 'productreviews',
         borderColor: '<?= Settings::getOption('trusted_shops/product_review_box_bordercolor') ?? "#0DBEDC" ?>',
         backgroundColor: '<?= Settings::getOption('trusted_shops/product_review_box_backgroundcolor') ?? "#FFFFFF" ?>',


### PR DESCRIPTION
Lazy loaded images are not displayed on some pages (ie. frontpage). This is because of a PHP error that blocks the loading of scripts below the ones related to this plugin. The problem is that rating/stars are being displayed on not single product pages.