### PR TITLE
Fixed disable badge on responsive replaced by sitewide setting

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -71,10 +71,10 @@ class Settings extends \WC_Integration {
         'description' => __('The Trusted Shop badge image.', Plugin::L10N),
         'desc_tip' => TRUE,
       ],
-      'trusted_shops/disable_responsive' => [
-        'title' => __('Disable responsive', Plugin::L10N),
+      'trusted_shops/disable_all_devices' => [
+        'title' => __('Disable for all devices', Plugin::L10N),
         'type' => 'checkbox',
-        'description' => __('If checked, the Trusted Shops responsive banner will be hidden on mobile devices.', Plugin::L10N),
+        'description' => __('If checked, the Trusted Shops responsive banner will be hidden on all devices.', Plugin::L10N),
         'desc_tip' => TRUE,
       ],
       'trusted_shops/display_product_stars' => [

--- a/src/TrustedShops.php
+++ b/src/TrustedShops.php
@@ -200,7 +200,7 @@ EOD;
       return;
     }
 
-    $disable_responsive = Settings::getOption('trusted_shops/disable_responsive') === 'yes' ? TRUE : FALSE;
+    $disable_all_devices = Settings::getOption('trusted_shops/disable_all_devices') === 'yes' ? TRUE : FALSE;
     $yOffset = Settings::getOption('trusted_shops/yOffset') ?? '0';
     $variant = Settings::getOption('trusted_shops/variant') ?? 'custom';
     ?>
@@ -214,8 +214,7 @@ EOD;
           'trustcardDirection': 'topRight',
           'customBadgeWidth': '40',
           'customBadgeHeight': '40',
-          'disableResponsive': '<?= $disable_responsive ?>',
-          'disableTrustbadge': 'false',
+          'disableTrustbadge': '<?= json_encode($disable_all_devices); ?>',
           'customCheckoutElementId': '<?= Plugin::PREFIX . '-trusted-shops-buyer-protection' ?>'
         };
         var _ts = document.createElement('script');


### PR DESCRIPTION
### Ticket
- [Reputations Plugin: backend options to hide the seal website-wide](https://app.asana.com/0/1200321652305036/1200283312531711/f)

### Description
- Added checkbox to the reputations plugin to hide badge on all devices: "disable for all devices". This setting is replacing and fixing the non working 'disable responsive' setting.
