### PR TITLE
Fixed TrustedShops checkout integration does not appear on order received page.

### DIFF
--- a/src/TrustedShops.php
+++ b/src/TrustedShops.php
@@ -186,7 +186,7 @@ EOD;
   public static function wp_footer() {
     global $product, $wpdb;
 
-    if (!$product || !$shop_id = Settings::getOption('trusted_shops/id')) {
+    if ((is_product() && !$product) || !$shop_id = Settings::getOption('trusted_shops/id')) {
       return;
     }
 


### PR DESCRIPTION
### Ticket
- [TrustedShops order parameters missing](https://app.asana.com/0/587433704548192/1202403908961935)

### Description
- The change in https://github.com/netzstrategen/woocommerce-reputations/pull/30 for [fatal error: products preview fail](https://app.asana.com/0/0/1202122575181944/f) caused the TrustedShops integration to not load at all anymore on the order received page, because there is no `global $product` loaded on that page.
