### PR TITLE
feat: add review widget

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -69,12 +69,8 @@ class Plugin {
     add_filter('woocommerce_thankyou_order_received_text', __NAMESPACE__ . '\TrustedShops::woocommerce_thankyou_order_received_text', 100, 2);
     // Shows etrusted Shop widget in cart page
     add_action('woocommerce_before_proceed_to_checkout', __NAMESPACE__ . '\TrustedShops::displayETrustedWidget');
-    if (defined('WC_VERSION') && WC_VERSION < '3.3.0') {
-      add_action('woocommerce_order_items_table', __NAMESPACE__ . '\TrustedShops::addsTrustedShopsBuyerProtection');
-    }
-    else {
-      add_action('woocommerce_order_details_after_order_table_items', __NAMESPACE__ . '\TrustedShops::addsTrustedShopsBuyerProtection');
-    }
+    // Display Trusted Shops widgets before order details table
+    add_action('woocommerce_order_details_before_order_table', __NAMESPACE__ . '\TrustedShops::addsTrustedShopsBuyerProtection');
     add_action('wp_footer', __NAMESPACE__ . '\TrustedShops::wp_footer');
     add_action(Plugin::PREFIX . '/badge/trusted-shops', __NAMESPACE__ . '\TrustedShops::renderBadge');
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -131,6 +131,12 @@ class Settings extends \WC_Integration {
         'description' => __('The logo URL to display in the review widget on the thank you page.', Plugin::L10N),
         'desc_tip' => TRUE,
       ],
+      'trusted_shops/review_widget_primary_color' => [
+        'title' => __('Review Widget Primary Color', Plugin::L10N),
+        'type' => 'color',
+        'description' => __('The primary color for the review widget (border and button).', Plugin::L10N),
+        'desc_tip' => TRUE,
+      ],
     ];
   }
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -125,6 +125,12 @@ class Settings extends \WC_Integration {
         'description' => __('The widget ID for the cart banner.', Plugin::L10N),
         'desc_tip' => TRUE,
       ],
+      'trusted_shops/review_widget_logo' => [
+        'title' => __('Review Widget Logo URL', Plugin::L10N),
+        'type' => 'text',
+        'description' => __('The logo URL to display in the review widget on the thank you page.', Plugin::L10N),
+        'desc_tip' => TRUE,
+      ],
     ];
   }
 

--- a/src/TrustedShops.php
+++ b/src/TrustedShops.php
@@ -311,10 +311,18 @@ EOD;
   /**
    * Adds trusted-shop-badge to the thank-you page.
    *
-   * @uses woocommerce_order_details_after_order_table_items
+   * @uses woocommerce_order_details_before_order_table
    */
-  public static function addsTrustedShopsBuyerProtection() {
-    echo '<div id="' . Plugin::PREFIX . '-trusted-shops-buyer-protection"></div>';
+  public static function addsTrustedShopsBuyerProtection($order = null) {
+    static::render_review_widget_styles();
+    ?>
+    <div class="<?php echo esc_attr(Plugin::PREFIX); ?>-trusted-shops-widgets">
+      <?php if ($order instanceof \WC_Order): ?>
+        <?php echo static::render_review_widget($order); ?>
+      <?php endif; ?>
+      <div id="<?php echo esc_attr(Plugin::PREFIX); ?>-trusted-shops-buyer-protection"></div>
+    </div>
+    <?php
   }
 
   /**
@@ -370,6 +378,148 @@ EOD;
         echo '<etrusted-widget style="display: block; margin: 0 0 0 auto; max-width: 430px" data-etrusted-widget-id="'. esc_attr($widget_id) . '"></etrusted-widget>';
       }
     }
+  }
+
+    /**
+   * Renders the review widget card for the thank you page.
+   *
+   * @param \WC_Order $order The WooCommerce order object.
+   * @return string The HTML markup for the review widget.
+   */
+  public static function render_review_widget($order): string {
+    $shop_id = Settings::getOption('trusted_shops/id');
+    if (empty($shop_id)) {
+      return '';
+    }
+
+    $logo_url = Settings::getOption('trusted_shops/review_widget_logo');
+    $button_color = Settings::getOption('trusted_shops/product_review_box_backgroundcolor') ?? '#4a7c59';
+    $shop_name = get_bloginfo('name');
+
+    // Build the review URL with encoded buyer email and order ID
+    $buyer_email = $order->get_billing_email();
+    $order_id = $order->get_id();
+
+    // Use custom order number if available
+    if (class_exists('Alg_WC_Custom_Order_Numbers_Core')) {
+      $order_id = get_post_meta($order->get_id(), '_alg_wc_custom_order_number', TRUE) ?: $order->get_id();
+    }
+
+    $review_url = sprintf(
+      'https://www.trustedshops.de/bewertung/bewerten_%s.html&buyerEmail=%s&shopOrderID=%s',
+      esc_attr($shop_id),
+      urlencode(base64_encode($buyer_email)),
+      urlencode(base64_encode($order_id))
+    );
+
+    ob_start();
+    ?>
+    <div class="woocommerce-reputations-review-widget">
+      <?php if ($logo_url): ?>
+      <div class="woocommerce-reputations-review-widget__logo">
+        <img src="<?php echo esc_url($logo_url); ?>" alt="<?php echo esc_attr($shop_name); ?>">
+      </div>
+      <?php endif; ?>
+
+      <h3 class="woocommerce-reputations-review-widget__title">
+        <?php esc_html_e('Bitte bewerten Sie Ihr Einkaufserlebnis:', Plugin::L10N); ?>
+      </h3>
+
+      <div class="woocommerce-reputations-review-widget__stars">
+        <span>★★★★★</span>
+      </div>
+
+      <p class="woocommerce-reputations-review-widget__text">
+        <?php esc_html_e('Wir leiten Sie für Ihre Bewertung zu Trusted Shops weiter.', Plugin::L10N); ?>
+      </p>
+
+      <div class="woocommerce-reputations-review-widget__button-wrap">
+        <a href="<?php echo esc_url($review_url); ?>"
+           target="_blank"
+           rel="noopener noreferrer"
+           class="woocommerce-reputations-review-widget__button">
+          <?php esc_html_e('Jetzt bewerten', Plugin::L10N); ?>
+        </a>
+      </div>
+    </div>
+    <?php
+    return ob_get_clean();
+  }
+
+  /**
+   * Outputs the CSS styles for the review widget and trusted shops widgets.
+   */
+  public static function render_review_widget_styles(): void {
+    $button_color = Settings::getOption('trusted_shops/product_review_box_backgroundcolor') ?? '#4a7c59';
+    ?>
+    <style>
+      .woocommerce-reputations-trusted-shops-widgets {
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+        margin: 20px 0;
+      }
+      .woocommerce-reputations-review-widget {
+        max-width: 400px;
+        border-top: 4px solid <?php echo esc_attr($button_color); ?>;
+        border-radius: 4px;
+        padding: 24px;
+        margin: 20px 0;
+        background: #fff;
+        font-family: Arial, sans-serif;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      }
+      .woocommerce-reputations-review-widget__logo {
+        text-align: center;
+        margin-bottom: 16px;
+        display: flex;
+        justify-content: center;
+      }
+      .woocommerce-reputations-review-widget__logo img {
+        max-width: 200px;
+        height: auto;
+      }
+      .woocommerce-reputations-review-widget__title {
+        text-align: center;
+        color: #000;
+        margin: 0 0 12px 0;
+        font-size: 18px;
+        font-weight: bold;
+      }
+      .woocommerce-reputations-review-widget__stars {
+        text-align: center;
+        margin-bottom: 16px;
+      }
+      .woocommerce-reputations-review-widget__stars span {
+        font-size: 32px;
+        color: #ccc;
+        letter-spacing: 4px;
+      }
+      .woocommerce-reputations-review-widget__text {
+        text-align: center;
+        color: #666;
+        font-size: 14px;
+        margin: 0 0 20px 0;
+      }
+      .woocommerce-reputations-review-widget__button-wrap {
+        text-align: center;
+      }
+      .woocommerce-reputations-review-widget__button {
+        display: inline-block;
+        background-color: <?php echo esc_attr($button_color); ?>;
+        color: #fff;
+        padding: 12px 32px;
+        text-decoration: none;
+        border-radius: 4px;
+        font-weight: bold;
+        font-size: 16px;
+      }
+      .woocommerce-reputations-review-widget__button:hover {
+        opacity: 0.9;
+        color: #fff;
+      }
+    </style>
+    <?php
   }
 
 }

--- a/src/TrustedShops.php
+++ b/src/TrustedShops.php
@@ -393,7 +393,6 @@ EOD;
     }
 
     $logo_url = Settings::getOption('trusted_shops/review_widget_logo');
-    $button_color = Settings::getOption('trusted_shops/product_review_box_backgroundcolor') ?? '#4a7c59';
     $shop_name = get_bloginfo('name');
 
     // Build the review URL with encoded buyer email and order ID
@@ -426,7 +425,9 @@ EOD;
       </h3>
 
       <div class="woocommerce-reputations-review-widget__stars">
-        <span>★★★★★</span>
+        <a href="<?php echo esc_url($review_url); ?>" target="_blank" rel="noopener noreferrer">
+          <span>★★★★★</span>
+        </a>
       </div>
 
       <p class="woocommerce-reputations-review-widget__text">
@@ -450,7 +451,7 @@ EOD;
    * Outputs the CSS styles for the review widget and trusted shops widgets.
    */
   public static function render_review_widget_styles(): void {
-    $button_color = Settings::getOption('trusted_shops/product_review_box_backgroundcolor') ?? '#4a7c59';
+    $primary_color = Settings::getOption('trusted_shops/review_widget_primary_color') ?? '#4a7c59';
     ?>
     <style>
       .woocommerce-reputations-trusted-shops-widgets {
@@ -460,14 +461,21 @@ EOD;
         margin: 20px 0;
       }
       .woocommerce-reputations-review-widget {
-        max-width: 400px;
-        border-top: 4px solid <?php echo esc_attr($button_color); ?>;
+        width: 474px;
+        max-width: 100%;
+        border-top: 4px solid <?php echo esc_attr($primary_color); ?>;
         border-radius: 4px;
         padding: 24px;
         margin: 20px 0;
         background: #fff;
         font-family: Arial, sans-serif;
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        box-sizing: border-box;
+      }
+      @media (max-width: 648px) {
+        .woocommerce-reputations-review-widget {
+          width: 308px;
+        }
       }
       .woocommerce-reputations-review-widget__logo {
         text-align: center;
@@ -506,7 +514,7 @@ EOD;
       }
       .woocommerce-reputations-review-widget__button {
         display: inline-block;
-        background-color: <?php echo esc_attr($button_color); ?>;
+        background-color: <?php echo esc_attr($primary_color); ?>;
         color: #fff;
         padding: 12px 32px;
         text-decoration: none;


### PR DESCRIPTION
This pull request enhances the integration of Trusted Shops review features on WooCommerce order pages. The main improvements include the addition of a customizable review widget, refactoring how and where widgets are displayed, and introducing new settings for better branding control.

**Review Widget Integration and Display Enhancements:**

* Added a new review widget to the order details page, allowing customers to rate their shopping experience directly after purchase. The widget includes a customizable logo, star rating, and a button linking to Trusted Shops with encoded order and customer information for security.
* Refactored the placement of Trusted Shops widgets so that the buyer protection and review widget now appear before the order details table, ensuring a more prominent and unified display. [[1]](diffhunk://#diff-c346b1aeac8259782c74702eadfe1d7a240ee3ecea6020ad2addede93c635cabL72-R73) [[2]](diffhunk://#diff-72d0b521f5d48a81cda4035ed38a88e19b5fc2724ab954bbc5fb40a59404cf62L314-R325)

**Customization and Settings:**

* Introduced a new setting field `trusted_shops/review_widget_logo` in `Settings.php`, allowing admins to specify a logo URL for the review widget, improving branding consistency on the thank you page.
* Added a method to output custom CSS styles for the review widget, with color customization based on admin settings for better visual integration with the shop’s theme.
---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212149015681034